### PR TITLE
Adding support for IR transmitters via GPIO

### DIFF
--- a/doc/Controllers.md
+++ b/doc/Controllers.md
@@ -53,14 +53,14 @@ Serial devices can be controlled by a local connection over a serial point. This
 
 ### Example
 
-        "crosspoint":{
-            "name":"Extron 300 Crosspoint",
-            "type":"serial",
-            "baud":9600,
-            "parity":"N",
-            "serial":"/dev/ttyUSB0",
-            "cmd_init":["#ESCZXXX"]
-        }
+    "crosspoint":{
+        "name":"Extron 300 Crosspoint",
+        "type":"serial",
+        "baud":9600,
+        "parity":"N",
+        "serial":"/dev/ttyUSB0",
+        "cmd_init":["#ESCZXXX"]
+    }
 
 
 ## Telnet
@@ -84,13 +84,13 @@ Telnet devices use a remote command line interface to accept commands. This soft
 
 Note this example doesn't provide a port because it is assumed to be `23` if not provided.
 
-        "in1606":{
-            "name":"Extron IN1606",
-            "type":"telnet",
-            "connection_skip":3,
-            "ip":"192.168.0.214",
-            "cmd_delay":0.05
-        }
+    "in1606":{
+        "name":"Extron IN1606",
+        "type":"telnet",
+        "connection_skip":3,
+        "ip":"192.168.0.214",
+        "cmd_delay":0.05
+    }
 
 
 ## HTTP GET
@@ -108,12 +108,12 @@ If your device has a basic HTTP URL API the this method will allow you to use th
 
 ### Example
 
-        "dvs510":{
-            "name":"Extron DVS 510",
-            "type":"http_get",
-            "ip":"192.168.0.109",
-            "uri":"/?cmd="
-        }
+    "dvs510":{
+        "name":"Extron DVS 510",
+        "type":"http_get",
+        "ip":"192.168.0.109",
+        "uri":"/?cmd="
+    }
 
 
 # Dedicated Interfaces
@@ -140,11 +140,11 @@ See [list of module functions](https://clvlabs.github.io/PyATEMMax/docs/methods/
 
 ### Example
 
-        "atem":{
-            "name":"Atem Pro Mini ISO",
-            "type":"atem",
-            "ip":"192.168.0.157"
-        }
+    "atem":{
+        "name":"Atem Pro Mini ISO",
+        "type":"atem",
+        "ip":"192.168.0.157"
+    }
 
 
 ## OBS
@@ -165,15 +165,35 @@ Web socket server must be enabled in OBS for this to work.
 
 ### Example
 
-        "stream-pc":{
-            "name":"Streaming Computer",
-            "type":"obs",
-            "timeout":3,
-            "password":"myawesomepassword",
-            "ip":"127.0.0.1",
-            "port":"4455"
-        }
+    "stream-pc":{
+        "name":"Streaming Computer",
+        "type":"obs",
+        "timeout":3,
+        "password":"myawesomepassword",
+        "ip":"127.0.0.1",
+        "port":"4455"
+    }
 
 
+## InfraRed
+
+*Requires [`PiIR`](https://github.com/ts1/PiIR) python module*
+
+*Requires [`pigpiod`](https://abyz.me.uk/rpi/pigpio/download.html) gpio daemon*
 
 
+Remote buttons are called by their names found in the json configuration for each remote.
+
+### Properties
+
+- `remote` : The json filename of the remote functions to use (remote configuration files should be in the `remotes` directory)
+- `gpio_pin` : The GPIO pin used to transmit the IR signals on
+
+### Example
+
+    "remote":{
+        "name":"LCD TV",
+        "type":"ir",
+        "remote":"sony_x750.json",
+        "gpio_pin":17
+    }

--- a/video-route.py
+++ b/video-route.py
@@ -142,6 +142,7 @@ class WebInterface(object):
         self.video_controllers["http_get"] = self.cmd_http_get
         self.video_controllers["atem"] = self.cmd_atem
         self.video_controllers["obs"] = self.cmd_obs
+        self.video_controllers["ir"] = self.cmd_ir
 
         # Module load information for each device type
         self.controller_modules = {}
@@ -194,7 +195,6 @@ class WebInterface(object):
                             import serial
                             import serial.tools.list_ports
                             self.controller_modules["serial"] = True
-
                         except Exception as e:
                             print("Need to install Python module [pyserial]")
                             sys.exit(1)
@@ -207,13 +207,11 @@ class WebInterface(object):
                             print("Need to install Python module [telnetlib3]")
                             sys.exit(1)
                     case "http_get":
-
                         global request_url
                         global parse
                         from urllib import request as request_url, parse
                         self.controller_modules["http_get"] = True
                     case "atem":
-
                         try:
                             global PyATEMMax
                             import PyATEMMax
@@ -222,13 +220,20 @@ class WebInterface(object):
                             print("Need to install Python module [PyATEMMax]")
                             sys.exit(1)
                     case "obs":
-
                         try:
                             global obs
                             import obsws_python as obs
                             self.controller_modules["obs"] = True
                         except Exception as e:
                             print("Need to install Python module [obsws-python]")
+                            sys.exit(1)
+                    case "ir":
+                        try:
+                            global ir
+                            import piir as ir
+                            self.controller_modules["ir"] = True
+                        except Exception as e:
+                            print("Need to install Python module [PiIR]")
                             sys.exit(1)
 
         # Skip initialization commands or not
@@ -381,6 +386,28 @@ class WebInterface(object):
                             pprint(getattr(data,data.attrs()[0]))
                     else:
                         print(f"Error with device [{name}]: OBS has no function [{function}]")
+                time.sleep(cmd_delay)
+
+        except Exception as e:
+            print(f"Error with device [{name}]:" + repr(e))
+
+
+    def cmd_ir(self,cmds,config):
+        """
+        Send IR signals through the GPIO pins on a Raspberry Pi.
+        Sending is typically on gpio pin 17 but can be configured using "gpio_pin":17.
+
+        :param cmds: Commands as list of of dicts with function name as key and parameters as value
+        :param config: Device controller configuration
+        :return: returns nothing
+        """
+        cmd_delay=config["cmd_delay"] if "cmd_delay" in config else 0
+        name=config["name"] if "name" in config else config["type"]
+        pin=config["gpio_pin"] if "gpio_pin" in config else 17
+        try:
+            remote = ir.Remote(f"remotes/{config['remote']}", pin)
+            for cmd in cmds:
+                remote.send(cmd)
                 time.sleep(cmd_delay)
 
         except Exception as e:


### PR DESCRIPTION
Implements IR transmission support using `PiIR` and `pigpiod` for use when running video-route on compatible Raspberry Pi devices.

Update (2025/05/12): I've been trying to get these widely available IR Transmitter modules working on the Pi but I don't think I have the correct circuit to drive the IR LED. I think the input pin wants the data at 5v but the Pi's GPIO is all 3.3v and a very tiny 16 milliamps... While I was able to read the remotes, I can get it to send. However the sending code in this PR is working at least~